### PR TITLE
Compile for TypeScript

### DIFF
--- a/src/compile/index.js
+++ b/src/compile/index.js
@@ -49,7 +49,7 @@ const compileJSX = (files, entry, output) => {
   }
 };
 
-const getNewFiles = entryPath => {
+const getNewFiles = entryPath =>
   walk(entryPath).filter(
     f =>
       f.indexOf('test') < 0 &&
@@ -58,7 +58,6 @@ const getNewFiles = entryPath => {
       f.indexOf('mock') < 0 &&
       !(f.endsWith('ts') || f.endsWith('tsx')),
   );
-};
 
 // if only tsx, compile them to jsx with tsc
 // then compile them to es5 with babel

--- a/src/compile/index.js
+++ b/src/compile/index.js
@@ -49,6 +49,17 @@ const compileJSX = (files, entry, output) => {
   }
 };
 
+const getNewFiles = entryPath => {
+  walk(entryPath).filter(
+    f =>
+      f.indexOf('test') < 0 &&
+      f.indexOf('html') < 0 &&
+      f.indexOf('demo') < 0 &&
+      f.indexOf('mock') < 0 &&
+      !(f.endsWith('ts') || f.endsWith('tsx')),
+  );
+};
+
 // if only tsx, compile them to jsx with tsc
 // then compile them to es5 with babel
 // for using babel plugins like babel-import
@@ -77,25 +88,9 @@ exports.compile = program => {
     let args = [tscBin];
     args.concat(additionalArgs).join(' ');
     runCmd('node', args, () => {
-      const newFiles = walk(entryPath).filter(
-        f =>
-          f.indexOf('test') < 0 &&
-          f.indexOf('html') < 0 &&
-          f.indexOf('demo') < 0 &&
-          f.indexOf('mock') < 0 &&
-          !(f.endsWith('ts') || f.endsWith('tsx')),
-      );
-      compileJSX(newFiles, entry, output);
+      compileJSX(getNewFiles(entryPath), entry, output);
     });
   } else {
-    const newFiles = walk(entryPath).filter(
-      f =>
-        f.indexOf('test') < 0 &&
-        f.indexOf('html') < 0 &&
-        f.indexOf('demo') < 0 &&
-        f.indexOf('mock') < 0 &&
-        !(f.endsWith('ts') || f.endsWith('tsx')),
-    );
-    compileJSX(newFiles, entry, output);
+    compileJSX(getNewFiles(entryPath), entry, output);
   }
 };

--- a/src/compile/index.js
+++ b/src/compile/index.js
@@ -75,6 +75,7 @@ exports.compile = program => {
     for (let file of files) {
       let outputPath = file.replace(entry, output);
       if (outputPath.endsWith('jsx') || outputPath.endsWith('js')) {
+        outputPath = outputPath.replace('jsx', 'js');
         const fileContent = fs.readFileSync(file, 'utf8');
         const result = babel.transformSync(fileContent, babelConfig);
         fs.outputFileSync(outputPath, result.code);


### PR DESCRIPTION
1. if only tsx, compile them to jsx with tsc

2. then compile them to es5 with babel, for using babel plugins like `babel-import`